### PR TITLE
Add role and permission management

### DIFF
--- a/laravel-api/app/Http/Controllers/PermissionController.php
+++ b/laravel-api/app/Http/Controllers/PermissionController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StorePermissionRequest;
+use App\Http\Requests\UpdatePermissionRequest;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use App\Services\PermissionService;
+use Illuminate\Http\JsonResponse;
+
+class PermissionController extends Controller
+{
+    public function __construct(private PermissionService $service)
+    {
+    }
+
+    public function index(): JsonResponse
+    {
+        return response()->json($this->service->all());
+    }
+
+    public function store(StorePermissionRequest $request): JsonResponse
+    {
+        $permission = $this->service->create($request->validated());
+
+        return response()->json($permission, 201);
+    }
+
+    public function show(Permission $permission): JsonResponse
+    {
+        return response()->json($permission);
+    }
+
+    public function update(UpdatePermissionRequest $request, Permission $permission): JsonResponse
+    {
+        $permission = $this->service->update($permission, $request->validated());
+
+        return response()->json($permission);
+    }
+
+    public function destroy(Permission $permission): JsonResponse
+    {
+        $this->service->delete($permission);
+
+        return response()->noContent();
+    }
+
+    public function assignToRole(Permission $permission, Role $role): JsonResponse
+    {
+        $this->service->assignToRole($permission, $role);
+
+        return response()->json(['message' => 'Permission assigned']);
+    }
+
+    public function removeFromRole(Permission $permission, Role $role): JsonResponse
+    {
+        $this->service->removeFromRole($permission, $role);
+
+        return response()->json(['message' => 'Permission removed']);
+    }
+
+    public function assignToUser(Permission $permission, User $user): JsonResponse
+    {
+        $this->service->assignToUser($permission, $user);
+
+        return response()->json(['message' => 'Permission assigned']);
+    }
+
+    public function removeFromUser(Permission $permission, User $user): JsonResponse
+    {
+        $this->service->removeFromUser($permission, $user);
+
+        return response()->json(['message' => 'Permission removed']);
+    }
+}

--- a/laravel-api/app/Http/Controllers/RoleController.php
+++ b/laravel-api/app/Http/Controllers/RoleController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreRoleRequest;
+use App\Http\Requests\UpdateRoleRequest;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\Permission;
+use App\Services\RoleService;
+use Illuminate\Http\JsonResponse;
+
+class RoleController extends Controller
+{
+    public function __construct(private RoleService $service)
+    {
+    }
+
+    public function index(): JsonResponse
+    {
+        return response()->json($this->service->all());
+    }
+
+    public function store(StoreRoleRequest $request): JsonResponse
+    {
+        $role = $this->service->create($request->validated());
+
+        return response()->json($role, 201);
+    }
+
+    public function show(Role $role): JsonResponse
+    {
+        return response()->json($role);
+    }
+
+    public function update(UpdateRoleRequest $request, Role $role): JsonResponse
+    {
+        $role = $this->service->update($role, $request->validated());
+
+        return response()->json($role);
+    }
+
+    public function destroy(Role $role): JsonResponse
+    {
+        $this->service->delete($role);
+
+        return response()->noContent();
+    }
+
+    public function assignPermission(Role $role, Permission $permission): JsonResponse
+    {
+        $this->service->assignPermission($role, $permission);
+
+        return response()->json(['message' => 'Permission assigned']);
+    }
+
+    public function removePermission(Role $role, Permission $permission): JsonResponse
+    {
+        $this->service->removePermission($role, $permission);
+
+        return response()->json(['message' => 'Permission removed']);
+    }
+
+    public function assignToUser(Role $role, User $user): JsonResponse
+    {
+        $this->service->assignToUser($role, $user);
+
+        return response()->json(['message' => 'Role assigned']);
+    }
+
+    public function removeFromUser(Role $role, User $user): JsonResponse
+    {
+        $this->service->removeFromUser($role, $user);
+
+        return response()->json(['message' => 'Role removed']);
+    }
+}

--- a/laravel-api/app/Http/Requests/StorePermissionRequest.php
+++ b/laravel-api/app/Http/Requests/StorePermissionRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePermissionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'category' => ['nullable', 'string'],
+            'is_system' => ['boolean'],
+        ];
+    }
+}

--- a/laravel-api/app/Http/Requests/StoreRoleRequest.php
+++ b/laravel-api/app/Http/Requests/StoreRoleRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRoleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'is_system' => ['boolean'],
+        ];
+    }
+}

--- a/laravel-api/app/Http/Requests/UpdatePermissionRequest.php
+++ b/laravel-api/app/Http/Requests/UpdatePermissionRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePermissionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'description' => ['sometimes', 'nullable', 'string'],
+            'category' => ['sometimes', 'nullable', 'string'],
+            'is_system' => ['sometimes', 'boolean'],
+        ];
+    }
+}

--- a/laravel-api/app/Http/Requests/UpdateRoleRequest.php
+++ b/laravel-api/app/Http/Requests/UpdateRoleRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRoleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'description' => ['sometimes', 'nullable', 'string'],
+            'is_system' => ['sometimes', 'boolean'],
+        ];
+    }
+}

--- a/laravel-api/app/Models/Permission.php
+++ b/laravel-api/app/Models/Permission.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Permission extends Model
+{
+    /** @use HasFactory */
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'category',
+        'is_system',
+    ];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class);
+    }
+
+    public function roles()
+    {
+        return $this->belongsToMany(Role::class);
+    }
+}

--- a/laravel-api/app/Models/Role.php
+++ b/laravel-api/app/Models/Role.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Role extends Model
+{
+    /** @use HasFactory */
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'is_system',
+    ];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class);
+    }
+
+    public function permissions()
+    {
+        return $this->belongsToMany(Permission::class);
+    }
+}

--- a/laravel-api/app/Models/User.php
+++ b/laravel-api/app/Models/User.php
@@ -6,6 +6,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Role;
+use App\Models\Permission;
 
 class User extends Authenticatable
 {
@@ -44,5 +46,15 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function roles()
+    {
+        return $this->belongsToMany(Role::class);
+    }
+
+    public function permissions()
+    {
+        return $this->belongsToMany(Permission::class);
     }
 }

--- a/laravel-api/app/Services/PermissionService.php
+++ b/laravel-api/app/Services/PermissionService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+
+class PermissionService
+{
+    public function all()
+    {
+        return Permission::all();
+    }
+
+    public function create(array $data): Permission
+    {
+        return Permission::create($data);
+    }
+
+    public function update(Permission $permission, array $data): Permission
+    {
+        $permission->update($data);
+
+        return $permission;
+    }
+
+    public function delete(Permission $permission): void
+    {
+        $permission->delete();
+    }
+
+    public function assignToRole(Permission $permission, Role $role): void
+    {
+        $role->permissions()->syncWithoutDetaching($permission);
+    }
+
+    public function removeFromRole(Permission $permission, Role $role): void
+    {
+        $role->permissions()->detach($permission);
+    }
+
+    public function assignToUser(Permission $permission, User $user): void
+    {
+        $user->permissions()->syncWithoutDetaching($permission);
+    }
+
+    public function removeFromUser(Permission $permission, User $user): void
+    {
+        $user->permissions()->detach($permission);
+    }
+}

--- a/laravel-api/app/Services/RoleService.php
+++ b/laravel-api/app/Services/RoleService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Role;
+use App\Models\Permission;
+use App\Models\User;
+
+class RoleService
+{
+    public function all()
+    {
+        return Role::all();
+    }
+
+    public function create(array $data): Role
+    {
+        return Role::create($data);
+    }
+
+    public function update(Role $role, array $data): Role
+    {
+        $role->update($data);
+
+        return $role;
+    }
+
+    public function delete(Role $role): void
+    {
+        $role->delete();
+    }
+
+    public function assignPermission(Role $role, Permission $permission): void
+    {
+        $role->permissions()->syncWithoutDetaching($permission);
+    }
+
+    public function removePermission(Role $role, Permission $permission): void
+    {
+        $role->permissions()->detach($permission);
+    }
+
+    public function assignToUser(Role $role, User $user): void
+    {
+        $user->roles()->syncWithoutDetaching($role);
+    }
+
+    public function removeFromUser(Role $role, User $user): void
+    {
+        $user->roles()->detach($role);
+    }
+}

--- a/laravel-api/database/migrations/2025_06_05_000001_create_roles_table.php
+++ b/laravel-api/database/migrations/2025_06_05_000001_create_roles_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('description')->nullable();
+            $table->boolean('is_system')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel-api/database/migrations/2025_06_05_000002_create_permissions_table.php
+++ b/laravel-api/database/migrations/2025_06_05_000002_create_permissions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('description')->nullable();
+            $table->string('category')->nullable();
+            $table->boolean('is_system')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/laravel-api/database/migrations/2025_06_05_000003_create_role_user_table.php
+++ b/laravel-api/database/migrations/2025_06_05_000003_create_role_user_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->primary(['role_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('role_user');
+    }
+};

--- a/laravel-api/database/migrations/2025_06_05_000004_create_permission_role_table.php
+++ b/laravel-api/database/migrations/2025_06_05_000004_create_permission_role_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('permission_role', function (Blueprint $table) {
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->primary(['permission_id', 'role_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permission_role');
+    }
+};

--- a/laravel-api/database/migrations/2025_06_05_000005_create_permission_user_table.php
+++ b/laravel-api/database/migrations/2025_06_05_000005_create_permission_user_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('permission_user', function (Blueprint $table) {
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->primary(['permission_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permission_user');
+    }
+};

--- a/laravel-api/routes/api.php
+++ b/laravel-api/routes/api.php
@@ -4,6 +4,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\TenantController;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\RoleController;
+use App\Http\Controllers\PermissionController;
 use Laravel\Sanctum\Http\Controllers\CsrfCookieController;
 
 Route::get('/user', function (Request $request) {
@@ -16,3 +18,15 @@ Route::post('/register', [AuthController::class, 'register']);
 Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');
 
 Route::apiResource('tenants', TenantController::class);
+Route::apiResource('roles', RoleController::class);
+Route::apiResource('permissions', PermissionController::class);
+
+Route::post('/roles/{role}/permissions/{permission}', [RoleController::class, 'assignPermission']);
+Route::delete('/roles/{role}/permissions/{permission}', [RoleController::class, 'removePermission']);
+Route::post('/users/{user}/roles/{role}', [RoleController::class, 'assignToUser']);
+Route::delete('/users/{user}/roles/{role}', [RoleController::class, 'removeFromUser']);
+
+Route::post('/permissions/{permission}/roles/{role}', [PermissionController::class, 'assignToRole']);
+Route::delete('/permissions/{permission}/roles/{role}', [PermissionController::class, 'removeFromRole']);
+Route::post('/users/{user}/permissions/{permission}', [PermissionController::class, 'assignToUser']);
+Route::delete('/users/{user}/permissions/{permission}', [PermissionController::class, 'removeFromUser']);


### PR DESCRIPTION
## Summary
- migrate permissions, roles and pivot tables
- create `Role` and `Permission` models
- add service layer to manage roles and permissions
- implement `RoleController` and `PermissionController`
- add validation requests for roles and permissions
- hook new APIs into `api.php`
- expose role and permission relations on `User`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840e0b7699c8322a2461b361e633446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive role and permission management, including creation, updating, deletion, and listing of roles and permissions via the API.
  - Added endpoints to assign and remove roles and permissions to/from users and roles, enabling granular access control.
- **API Enhancements**
  - Expanded API routes to support all role and permission management operations.
- **Database**
  - Added new tables for roles, permissions, and their relationships with users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->