### PR TITLE
Add API helpers for user, role, and permission management

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -59,3 +59,91 @@ export async function logout() {
     headers: { "Content-Type": "application/json" },
   });
 }
+
+export async function getUsers() {
+  return request(`${API_BASE}/users`);
+}
+
+export async function createUser(data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateUser(id: number | string, data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/users/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteUser(id: number | string) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/users/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function getRoles() {
+  return request(`${API_BASE}/roles`);
+}
+
+export async function createRole(data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/roles`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateRole(id: number | string, data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/roles/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteRole(id: number | string) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/roles/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function getPermissions() {
+  return request(`${API_BASE}/permissions`);
+}
+
+export async function createPermission(data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/permissions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updatePermission(id: number | string, data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/permissions/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deletePermission(id: number | string) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/permissions/${id}`, {
+    method: "DELETE",
+  });
+}
+


### PR DESCRIPTION
## Summary
- add new API helpers for users
- add CRUD helpers for roles and permissions

## Testing
- `npm run build` *(fails: Failed to fetch fonts and syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840e4c9261c8322a105f2e2ba406cd7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to manage users, roles, and permissions through new create, read, update, and delete actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->