### PR TITLE
Switch user management to API data

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -59,3 +59,93 @@ export async function logout() {
     headers: { "Content-Type": "application/json" },
   });
 }
+
+// User APIs
+export async function getUsers() {
+  return request(`${API_BASE}/users`);
+}
+
+export async function createUser(data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateUser(id: string, data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/users/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteUser(id: string) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/users/${id}`, {
+    method: "DELETE",
+  });
+}
+
+// Role APIs
+export async function getRoles() {
+  return request(`${API_BASE}/roles`);
+}
+
+export async function createRole(data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/roles`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateRole(id: string, data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/roles/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteRole(id: string) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/roles/${id}`, {
+    method: "DELETE",
+  });
+}
+
+// Permission APIs
+export async function getPermissions() {
+  return request(`${API_BASE}/permissions`);
+}
+
+export async function createPermission(data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/permissions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updatePermission(id: string, data: Record<string, any>) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/permissions/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deletePermission(id: string) {
+  await getCsrfCookie();
+  return request(`${API_BASE}/permissions/${id}`, {
+    method: "DELETE",
+  });
+}


### PR DESCRIPTION
## Summary
- remove mock data from user management section
- add REST functions to `api.ts`
- fetch users, roles and permissions from the backend and update via API

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: PromptFlowSection.tsx errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840e4c656c083228bae2b6143768348